### PR TITLE
bug fix: 32bit overflow of offset value in Raw Read and Raw Write 

### DIFF
--- a/ext/fusefs_lib.c
+++ b/ext/fusefs_lib.c
@@ -660,7 +660,8 @@ rf_open(const char *path, struct fuse_file_info *fi) {
     /* We have the body, now save it the entire contents to our
      * opened_file lists. */
     newfile = ALLOC(opened_file);
-    value = rb_str2cstr(body,&newfile->size);
+    value = StringValueCStr(body);
+    newfile->size = strlen(value);
     newfile->value = ALLOC_N(char,(newfile->size)+1);
     memcpy(newfile->value,value,newfile->size);
     newfile->value[newfile->size] = '\0';
@@ -715,7 +716,8 @@ rf_open(const char *path, struct fuse_file_info *fi) {
       /* We have the body, now save it the entire contents to our
        * opened_file lists. */
       newfile = ALLOC(opened_file);
-      value = rb_str2cstr(body,&newfile->size);
+      value = StringValueCStr(body);
+      newfile->size = strlen(value);
       newfile->value = ALLOC_N(char,(newfile->size)+1);
       memcpy(newfile->value,value,newfile->size);
       newfile->writesize = newfile->size+1;
@@ -1074,7 +1076,8 @@ rf_truncate(const char *path, off_t offset) {
       rf_call(path,id_write_to,newstr);
     } else {
       long size;
-      char *str = rb_str2cstr(body,&size);
+      char *str = StringValueCStr(body);
+      size = strlen(str);
 
       /* Just in case offset is bigger than the file. */
       if (offset >= size) return 0;


### PR DESCRIPTION
hello duairc.

i found a bug related to offset overflow today. so i checked fuse_lib.c, and found it.
( requesting over 2,147,483,647, 2^32-1, causes offset value to be negative value. )

type of the argument, off_t offset, is valid, but converting the value into Ruby's value causes this overflow.
 INT2NUM(offset) --> LONG2NUM(offset)

on my environment, Fedora12@x86-64 and CentOS5@i686 can make successfully.
fixing this, i confirmed to works fine like this:
 dd if=fuse/image.dat of=/dev/null bs=1M count=256, skip=2047
 (without this fix, requesting to 2048th block causes overflow. fusefs calls raw_read with negative offset.)

PS: sorry for adding some emptyline diffs in this request... i think this is caused by emacs, but i don't know why this happend and how to stop it :-(
