### PR TITLE
Update fusefs Ruby/C extensions to be Ruby 1.9 compatible

### DIFF
--- a/ext/fusefs_lib.c
+++ b/ext/fusefs_lib.c
@@ -452,7 +452,7 @@ rf_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
     if (TYPE(cur_entry) != T_STRING)
       continue;
 
-    filler(buf,STR2CSTR(cur_entry),NULL,0);
+    filler(buf,StringValuePtr(cur_entry),NULL,0);
   }
   return 0;
 }
@@ -1390,7 +1390,7 @@ rf_mount_to(int argc, VALUE *argv, VALUE self) {
   }
 
   rb_iv_set(cFuseFS,"@mountpoint",mountpoint);
-  fusefs_setup(STR2CSTR(mountpoint), &rf_oper, opts);
+  fusefs_setup(StringValuePtr(mountpoint), &rf_oper, opts);
   return Qtrue;
 }
 


### PR DESCRIPTION
Now that Ruby 1.8.7 (and thus 1.8.x) has been [retired](http://www.ruby-lang.org/en/news/2013/06/30/we-retire-1-8-7/) officially, I am submitted a pull request to remove 1.9+ Ruby/C extension incompatibility. Removing `STR2CSTR` and replacing with the 1.9.x+ `StringValuePtr`.
