### PR TITLE
port to Ruby1.9+ a little bit further

### DIFF
--- a/ext/fusefs_lib.c
+++ b/ext/fusefs_lib.c
@@ -17,6 +17,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <ruby.h>
+#include <unistd.h>
+#include <ctype.h>
 
 #ifdef DEBUG
 #include <stdarg.h>
@@ -660,7 +662,8 @@ rf_open(const char *path, struct fuse_file_info *fi) {
     /* We have the body, now save it the entire contents to our
      * opened_file lists. */
     newfile = ALLOC(opened_file);
-    value = rb_str2cstr(body,&newfile->size);
+    value = RSTRING_PTR(body);
+    newfile->size = RSTRING_LEN(body);
     newfile->value = ALLOC_N(char,(newfile->size)+1);
     memcpy(newfile->value,value,newfile->size);
     newfile->value[newfile->size] = '\0';
@@ -715,7 +718,8 @@ rf_open(const char *path, struct fuse_file_info *fi) {
       /* We have the body, now save it the entire contents to our
        * opened_file lists. */
       newfile = ALLOC(opened_file);
-      value = rb_str2cstr(body,&newfile->size);
+      value = RSTRING_PTR(body);
+      newfile->size = RSTRING_LEN(body);
       newfile->value = ALLOC_N(char,(newfile->size)+1);
       memcpy(newfile->value,value,newfile->size);
       newfile->writesize = newfile->size+1;
@@ -1074,7 +1078,8 @@ rf_truncate(const char *path, off_t offset) {
       rf_call(path,id_write_to,newstr);
     } else {
       long size;
-      char *str = rb_str2cstr(body,&size);
+      char *str = RSTRING_PTR(body);
+      size = RSTRING_LEN(body);
 
       /* Just in case offset is bigger than the file. */
       if (offset >= size) return 0;


### PR DESCRIPTION
Hi!

To have ruby-fusefs work with ruby1.9.3/ruby2.0 on Debian, I had to do the following changes. Please consider adding this patch. It built fine and I managed to run a couple of examples (hello.rb, demo.rb, yamlfs.rb).

Could you please consider releasing a new gem, at least for 0.7.1? The latest available 0.7.0 still has the typo RSTRING_LEN instead of RSTRING_PTR in the code.

Thanks!
